### PR TITLE
Score_entry: Correct touch/sprawl penalty amounts

### DIFF
--- a/Web Pages/Data.xml
+++ b/Web Pages/Data.xml
@@ -156,10 +156,10 @@
         <Option><Label>2</Label><Value>20</Value></Option>
         <Option><Label>3</Label><Value>30</Value></Option>
         <Option><Label>4</Label><Value>40</Value></Option>
-        <Option><Label>5</Label><Value>43</Value></Option>
-        <Option><Label>6</Label><Value>46</Value></Option>
-        <Option><Label>7</Label><Value>49</Value></Option>
-        <Option><Label>8</Label><Value>52</Value></Option>
+        <Option><Label>5</Label><Value>53</Value></Option>
+        <Option><Label>6</Label><Value>66</Value></Option>
+        <Option><Label>7</Label><Value>79</Value></Option>
+        <Option><Label>8</Label><Value>92</Value></Option>
         <Score><![CDATA[score -= (this.answers['touch'] || 0);]]></Score>
     </Element>
 


### PR DESCRIPTION
Update 21 clarifies the penalty cost:
21 – CALCULATING ROOF PENALTIES
You can get up to eight sprawl and/or touch penalties, as represented by the roof debris on the mat.  The Missions page is unclear on the following fact:  Here is the cost for penalty accumulation:  1=10, 2=20, 3=30, 4=40, 5=53, 6=66, 7=79, 8=92.  Sorry for the confusion.  This far into the season I would normally be unable to make such a serious correction, but I trust no one was developing a penalty-based strategy.
Signed-off-by:Courtney Goeltzenleuchter courtney@coloradofirst.org
