### PR TITLE
Into Orbit scoring

### DIFF
--- a/Protected Webpages/Score_Entry.html
+++ b/Protected Webpages/Score_Entry.html
@@ -510,7 +510,7 @@
             <div id="mid-header" align="center">
                 <div id="mid-header-title">
                     <em>FIRST</em> LEGO League <br />
-                    <em>Hydro Dynamics</em> Score Sheet
+                    <em>Into Orbit</em> Score Sheet
                 </div>
                 <div id="team_name_header">Select Team</div>
             </div>

--- a/language/Data.xml
+++ b/language/Data.xml
@@ -2,367 +2,293 @@
 <Scoring_Elements>
 
     <Element>
-        <Heading>M01 Pipe Removal</Heading>
-        <Question>Broken Pipe complete in Base</Question>
-        <Tag>m01</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m01'] || 0)*20;]]></Score>
+        <Heading>M01 Space Travel</Heading>
+        <Question>Vehicle Payload rolled past first track connection</Question>
+        <Tag>m01a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m01a'] || 0) * 22;]]></Score>
     </Element>
-    
+
     <Element>
-	<Heading>M02 Flow</Heading>
-	<Question>Big Water is on other team's field</Question>
-        <Tag>m02</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m02'] || 0)*25;]]></Score>
-        <Validate><![CDATA[(
-	                    (this.answers['m02'] || 0)*1  + 
-	                    (this.answers['m07'] || 0)*1  + 
-	                    (this.answers['m13a'] || 0)*1  + 
-	                    (this.answers['m16c'] || 0)*1  + 
-                            (this.answers['m16d'] || 0)*1 > (5 - (1 - (this.answers['m06'] || 0)*1))) ?
-                           {'highlight': true, 'msg':'Too many big waters in use.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
+        <Heading>M01 Space Travel</Heading>
+        <Question>Supply Payload rolled past first track connection</Question>
+        <Tag>m01b</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m01b'] || 0) * 14;]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M01 Space Travel</Heading>
+        <Question>Crew Payload rolled past first track connection</Question>
+        <Tag>m01c</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m01c'] || 0) * 10;]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M02 Solar Panel Array</Heading>
+        <Question>Both Solar Panels are angled toward the same Field</Question>
+        <Tag>m02a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m02a'] || 0) * 22;]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M02 Solar Panel Array</Heading>
+        <Question>Your Solar Panel is angled to other team's Field</Question>
+        <Tag>m02b</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m02b'] || 0) * 18;]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M03 3D Printing</Heading>
+        <Question>2×4 Brick is ejected</Question>
+        <Info>Due only to a Regolith Core Sample in the 3D Printer</Info>
+        <Tag>m03a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+    </Element>
+
+    <Element>
+        <Heading>M03 3D Printing</Heading>
+        <Question>2×4 Brick is completely in Northeast Planet Area</Question>
+        <Tag>m03b</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m03a'] || 0) * ((this.answers['m03b'] || 0) * 1 ? 22 : 18);]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M04 Crater Crossing</Heading>
+        <Question>All weight-bearing features of crossing equipment crossed completely between towers</Question>
+        <Tag>m04a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+    </Element>
+
+    <Element>
+        <Heading>M04 Crater Crossing</Heading>
+        <Question>All crossing equipment crossed from east to west, completely past flattened Gate</Question>
+        <Tag>m04b</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += ((this.answers['m04a'] || 0) * 1 && (this.answers['m04b'] || 0) * 1) ? 20 : 0;]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M05 Extraction</Heading>
+        <Question>All four Core Samples no longer touching axle of Core Site Model</Question>
+        <Tag>m05a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m05a'] || 0) * 16;]]></Score>
+        <!-- U02 - Some Core Samples: m05a not needed for others -->
+    </Element>
+
+    <Element>
+        <Heading>M05 Extraction</Heading>
+        <Question>Gas Core Sample touching Mat &amp; completely in Lander's Target Circle</Question>
+        <Tag>m05b</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m05b'] || 0) * 12;]]></Score>
+        <Validate><![CDATA[((this.answers['m05b'] || 0) * 1 &&
+                            (this.answers['m05c'] || 0) * 1) ?
+                           {'highlight': true, 'msg': 'Gas Core Sample cannot be both in Lander\'s Target Circle and Base'} : // validation failed
+                           {'highlight': false, 'msg': ''};]]>
         </Validate>
     </Element>
 
     <Element>
-	<Heading>M03 Pump Addition</Heading>
-	<Question>Pump Addition has contact with the mat completely inside the target area</Question>
-        <Tag>m03</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m03'] || 0)*20;]]></Score>
+        <Heading>M05 Extraction</Heading>
+        <Question>Gas Core Sample is completely in Base</Question>
+        <Tag>m05c</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m05c'] || 0) * 10;]]></Score>
+        <Validate><![CDATA[((this.answers['m05b'] || 0) * 1 &&
+                            (this.answers['m05c'] || 0) * 1) ?
+                           {'highlight': true, 'msg': 'Gas Core Sample cannot be both in Lander\'s Target Circle and Base'} : // validation failed
+                           {'highlight': false, 'msg': ''};]]>
+        </Validate>
     </Element>
 
     <Element>
-	<Heading>M04 Rain</Heading>
-	<Question>At least one Rain is out of the Rain Cloud</Question>
-        <Tag>m04</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m04'] || 0)*20;]]></Score>
+        <Heading>M05 Extraction</Heading>
+        <Question>Water Core Sample supported only by Food Growth Chamber</Question>
+        <Tag>m05d</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m05d'] || 0) * 8;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M05 Filter</Heading>
-	<Question>Lock latch is in dropped position</Question>
-        <Tag>m05</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m05'] || 0)*30;]]></Score>
+        <Heading>M06 Space Station Module</Heading>
+        <Question>Cone Module is completely in Base</Question>
+        <Tag>m06a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m06a'] || 0) * 16;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M06 Water Treatment</Heading>
-	<Question>Big Water is ejected from Water Treatment model</Question>
-        <Tag>m06</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m06'] || 0)*20;]]></Score>
+        <Heading>M06 Space Station Module</Heading>
+        <Question>Tube Module is in west port of Habitation Hub</Question>
+        <Tag>m06b</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m06b'] || 0) * 16;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M07 Fountain</Heading>
-	<Question>Middle layer is raised</Question>
+        <Heading>M06 Space Station Module</Heading>
+        <Question>Dock Module is in east port of Habitation Hub</Question>
+        <Tag>m06c</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m06c'] || 0) * 14;]]></Score>
+    </Element>
+
+    <Element>
+        <Heading>M07 Space Walk Emergency</Heading>
+        <Question>Astronaut "Gerhard" is in the Habitation Hub's Airlock Chamber</Question>
         <Tag>m07</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m07'] || 0)*20;]]></Score>
-        <Validate><![CDATA[(
-	                    (this.answers['m02'] || 0)*1  + 
-	                    (this.answers['m07'] || 0)*1  + 
-	                    (this.answers['m13a'] || 0)*1  + 
-	                    (this.answers['m16c'] || 0)*1  + 
-                            (this.answers['m16d'] || 0)*1 > (5 - (1 - (this.answers['m06'] || 0)*1))) ?
-                           {'highlight': true, 'msg':'Too many big waters in use.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Partly</Label><Value>18</Value></Option>
+        <Option><Label>Completely</Label><Value>22</Value></Option>
+        <Score><![CDATA[score += (this.answers['m07'] || 0) * 1;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M08 Manhole Covers</Heading>
-	<Question>Manhole cover(s) are flipped over past vertical</Question>
-        <Tag>m08a</Tag>
-        <Option><Label>0</Label><Value>0</Value><Default/></Option>
-        <Option><Label>1</Label><Value>1</Value></Option>
-        <Option><Label>2</Label><Value>2</Value></Option>
-        <Score><![CDATA[score += (this.answers['m08a'] || 0)*15;]]></Score>
-    </Element>
-    
-    <Element>
-	<Heading>M08 Manhole Covers</Heading>
-	<Question>Both covers are flipped over and completely in separate Tripod target</Question>
-        <Tag>m08b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m08a'] || 0) == 2 ? (this.answers['m08b'] || 0)*30 : 0;]]></Score>
-        <Validate><![CDATA[(((this.answers['m08b'] || 0)*1 && 
-                            ((this.answers['m08a'] || 0)*1) < 2)) ?
-                           {'highlight': true, 'msg':'Both Manhole covers must be flipped to score bonus.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
-    </Element>
-    
-    <Element>
-	<Heading>M09 Tripod</Heading>
-	<Question>All the Tripod's feet are touching the mat</Question>
-        <Tag>m09a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
+        <Heading>M08 Aerobic Exercise</Heading>
+        <Question>Exercise Pointer tip is in</Question>
+        <Info>Due only to moving one or both Handle Assemblies</Info>
+        <Tag>m08</Tag>
+        <Option><Label>None</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Gray</Label><Value>18</Value></Option>
+        <Option><Label>White</Label><Value>20</Value></Option>
+        <Option><Label>Orange</Label><Value>22</Value></Option>
+        <Score><![CDATA[score += (this.answers['m08'] || 0) * 1;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M09 Tripod</Heading>
-	<Question>Tripod is partially in a Tripod target</Question>
-        <Tag>m09b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m09a'] || 0)*1 && (this.answers['m09b'] || 0)*1 ? 15 : 0;]]></Score>
-        <Validate><![CDATA[((this.answers['m09b'] || 0)*1 && 
-                            (this.answers['m09c'] || 0)*1) ?
-                           {'highlight': true, 'msg':'Tripod cannot be both partially and completely in target.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
+        <Heading>M09 Strength Exercise</Heading>
+        <Question>Strength Bar lifted so that tooth-strip's 4th hole is at least partly in view</Question>
+        <Tag>m09</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m09'] || 0) * 16;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M09 Tripod</Heading>
-	<Question>Tripod is completely in a Tripod target</Question>
-        <Tag>m09c</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m09a'] || 0)*1 && (this.answers['m09c'] || 0)*1 ? 20 : 0;]]></Score>
-        <Validate><![CDATA[((this.answers['m09b'] || 0)*1 && 
-                            (this.answers['m09c'] || 0)*1) ?
-                           {'highlight': true, 'msg':'Tripod cannot be both partially and completely in target.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
+        <Heading>M10 Food Production</Heading>
+        <Question>Grey weight is dropped after green, but before tan</Question>
+        <Info>Due only to moving the Push Bar</Info>
+        <Tag>m10</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m10'] || 0) * 16;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M10 Pipe Replacement</Heading>
-	<Question>New pipe is installed where Broken Pipe was</Question>
-        <Tag>m10a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
+        <Heading>M11 Escape Velocity</Heading>
+        <Question>Spacecraft stays up</Question>
+        <Info>Due only to pressing/hitting Strike Pad</Info>
+        <Tag>m11</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
+        <Score><![CDATA[score += (this.answers['m11'] || 0) * 24;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M10 Pipe Replacement</Heading>
-	<Question>This New Pipe has full/flat contact with the mat</Question>
-        <Tag>m10b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += ((this.answers['m10a'] || 0)*1) && ((this.answers['m10b'] || 0)*1) ? 20 : 0;]]></Score>
-    </Element>
-
-    <Element>
-	<Heading>M11 Pipe Construction</Heading>
-	<Question>New Pipe has full/flat contact with the mat</Question>
-        <Tag>m11a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-    </Element>
-
-    <Element>
-	<Heading>M11 Pipe Construction</Heading>
-	<Question>This New Pipe is partially in its target</Question>
-        <Tag>m11b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += ((this.answers['m11a'] || 0)*1) && ((this.answers['m11b'] || 0)*1) ? 15 : 0;]]></Score>
-        <Validate><![CDATA[(((this.answers['m11b'] || 0)*1  &&
-                            (this.answers['m11c'] || 0)*1) ) ?
-                           {'highlight': true, 'msg':'Pipe cannot be both partially and completely in its target.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
-    </Element>
-
-    <Element>
-	<Heading>M11 Pipe Construction</Heading>
-	<Question>This New Pipe is completely in its target</Question>
-        <Tag>m11c</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += ((this.answers['m11a'] || 0)*1) && ((this.answers['m11c'] || 0)*1) ? 20 : 0;]]></Score>
-        <Validate><![CDATA[(((this.answers['m11b'] || 0)*1  &&
-                            (this.answers['m11c'] || 0)*1) ) ?
-                           {'highlight': true, 'msg':'Pipe cannot be both partially and completely in its target.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
-    </Element>
-
-    <Element>
-	<Heading>M12 Sludge</Heading>
-	<Question>Sludge touching visible wood of a drawn garden box</Question>
+        <Heading>M12 Satellite Orbits</Heading>
+        <Question>Satellites on or above the area between the two lines of Outer Orbit</Question>
         <Tag>m12</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m12'] || 0)*30;]]></Score>
+        <Option><Label>0</Label><Value>0</Value><Default/></Option>
+        <Option><Label>1</Label><Value>1</Value></Option>
+        <Option><Label>2</Label><Value>2</Value></Option>
+        <Option><Label>3</Label><Value>3</Value></Option>
+        <Score><![CDATA[score += (this.answers['m12'] || 0) * 8;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M13 Flower</Heading>
-	<Question>Flower is raised</Question>
-        <Tag>m13a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m13a'] || 0)*30;]]></Score>
-        <Validate><![CDATA[(
-	                    (this.answers['m02'] || 0)*1  + 
-	                    (this.answers['m07'] || 0)*1  + 
-	                    (this.answers['m13a'] || 0)*1  + 
-	                    (this.answers['m16c'] || 0)*1  + 
-                            (this.answers['m16d'] || 0)*1 > (5 - (1 - (this.answers['m06'] || 0)*1))) ?
-                           {'highlight': true, 'msg':'Too many big waters in use.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
+        <Heading>M13 Observatory</Heading>
+        <Question>The Observatory pointer tip is in</Question>
+        <Tag>m13</Tag>
+        <Option><Label>None</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Gray</Label><Value>16</Value></Option>
+        <Option><Label>White</Label><Value>18</Value></Option>
+        <Option><Label>Orange</Label><Value>20</Value></Option>
+        <Score><![CDATA[score += (this.answers['m13'] || 0) * 1;]]></Score>
     </Element>
 
     <Element>
-	<Heading>M13 Flower</Heading>
-	<Question>At least one rain is in the purple part, touching nothing bug Flower model</Question>
-        <Tag>m13b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m13a'] || 0)*1 && (this.answers['m13b'] || 0)*1 ? 30 : 0;]]></Score>
-    </Element>
-
-    <Element>
-	<Heading>M14 Water Well</Heading>
-	<Question>Water Well contacting mat partially inside target area</Question>
+        <Heading>M14 Meteoroid Deflection</Heading>
+        <Question>Meteoroids touching the Mat and in the Center Section</Question>
         <Tag>m14a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m14a'] || 0)*15;]]></Score>
-        <Validate><![CDATA[((((this.answers['m14a'] || 0)*1 > 0) &&
-                            ((this.answers['m14b'] || 0)*1) > 0)) ?
-                           {'highlight': true, 'msg':'Well cannot be both partially and completely within target.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
+        <Option><Label>0</Label><Value>0</Value><Default/></Option>
+        <Option><Label>1</Label><Value>1</Value></Option>
+        <Option><Label>2</Label><Value>2</Value></Option>
+        <Score><![CDATA[score += (this.answers['m14a'] || 0) * 12;]]></Score>
+        <Validate><![CDATA[((this.answers['m14a'] || 0) * 1 +
+                            (this.answers['m14b'] || 0) * 1 > 2) ?
+                           {'highlight': true, 'msg': 'Too many meteoroids in use'} : // validation failed
+                           {'highlight': false, 'msg': ''};]]>
         </Validate>
     </Element>
-    
+
     <Element>
-	<Heading>M14 Water Well</Heading>
-	<Question>Water Well contacting mat completely inside target area</Question>
+        <Heading>M14 Meteoroid Deflection</Heading>
+        <Question>Meteoroids touching the Mat and in Either Side Section</Question>
         <Tag>m14b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-	// TODO: fix up validation and score
-        <Score><![CDATA[score += (this.answers['m14b'] || 0)*25;]]></Score>
-        <Validate><![CDATA[((((this.answers['m14a'] || 0)*1 > 0) &&
-                            ((this.answers['m14b'] || 0)*1) > 0)) ?
-                           {'highlight': true, 'msg':'Well cannot be both partially and completely within target.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
+        <Option><Label>0</Label><Value>0</Value><Default/></Option>
+        <Option><Label>1</Label><Value>1</Value></Option>
+        <Option><Label>2</Label><Value>2</Value></Option>
+        <Score><![CDATA[score += (this.answers['m14b'] || 0) * 8;]]></Score>
+        <Validate><![CDATA[((this.answers['m14a'] || 0) * 1 +
+                            (this.answers['m14b'] || 0) * 1 > 2) ?
+                           {'highlight': true, 'msg': 'Too many meteoroids in use'} : // validation failed
+                           {'highlight': false, 'msg': ''};]]>
         </Validate>
     </Element>
-    
+
     <Element>
-	<Heading>M15 Fire</Heading>
-	<Question>Fire is dropped</Question>
-        <Tag>m15</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m15'] || 0)*25;]]></Score>
+        <Heading>M15 Lander Touch-Down</Heading>
+        <Question>Lander is intact and touching the Mat</Question>
+        <Tag>m15a</Tag>
+        <Option><Label>No</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Yes</Label><Value>1</Value></Option>
     </Element>
 
     <Element>
-	<Heading>M16 Water Collection</Heading>
-	<Question>Water Target is East of Off-Limits line</Question>
-        <Tag>m16a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
+        <Heading>M15 Lander Touch-Down</Heading>
+        <Question>Lander is completely in</Question>
+        <Tag>m15b</Tag>
+        <Option><Label>None</Label><Value>0</Value><Default/></Option>
+        <Option><Label>Base</Label><Value>16</Value></Option>
+        <Option><Label>Northeast Planet Area</Label><Value>20</Value></Option>
+        <Option><Label>Target Circle</Label><Value>22</Value></Option>
+        <Score><![CDATA[score += (this.answers['m15b'] || 0) * ((this.answers['m15b'] || 0) * 1 == 16 ? 1 : (this.answers['m15a'] || 0) * 1)]]></Score>
     </Element>
 
     <Element>
-	<Heading>M16 Water Collection</Heading>
-	<Question>At least one Rain is touching mat in the Water Target</Question>
-        <Tag>m16b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m16a'] || 0)*1 && (this.answers['m16b'] || 0)*1 ? 10 : 0;]]></Score>
-    </Element>
-
-    <Element>
-	<Heading>M16 Water Collection</Heading>
-	<Question>Big Water touching mat in the Water Target</Question>
-        <Tag>m16c</Tag>
+        <Heading>Penalties</Heading>
+        <Question>Penalty discs in the southeast triangle</Question>
+        <Tag>p01</Tag>
         <Option><Label>0</Label><Value>0</Value><Default/></Option>
         <Option><Label>1</Label><Value>1</Value></Option>
         <Option><Label>2</Label><Value>2</Value></Option>
         <Option><Label>3</Label><Value>3</Value></Option>
         <Option><Label>4</Label><Value>4</Value></Option>
         <Option><Label>5</Label><Value>5</Value></Option>
-        <Score><![CDATA[score += (this.answers['m16a'] || 0)*1 > 0 ? (this.answers['m16c'] || 0)*10 : 0;]]></Score>
-        <Validate><![CDATA[(
-	                    (this.answers['m02'] || 0)*1  + 
-	                    (this.answers['m07'] || 0)*1  + 
-	                    (this.answers['m13a'] || 0)*1  + 
-	                    (this.answers['m16c'] || 0)*1  + 
-                            (this.answers['m16d'] || 0)*1 > (5 - (1 - (this.answers['m06'] || 0)*1))) ?
-                           {'highlight': true, 'msg':'Too many big waters in use.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
+        <Option><Label>6</Label><Value>6</Value></Option>
+        <Score><![CDATA[score -= (this.answers['p01'] || 0) * 3;]]></Score>
     </Element>
 
-    <Element>
-        <Heading>M16 Water Collection</Heading>
-	<Question>At least one pair of Big Waters stacked in Water Target</Question>
-        <Tag>m16d</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m16a'] || 0)*1 && (this.answers['m16d'] || 0)*1 ? 30 : 0;]]></Score>
-        <Validate><![CDATA[(
-	                    (this.answers['m02'] || 0)*1  + 
-	                    (this.answers['m07'] || 0)*1  + 
-	                    (this.answers['m13a'] || 0)*1  + 
-	                    (this.answers['m16c'] || 0)*1  + 
-                            (this.answers['m16d'] || 0)*1 > (5 - (1 - (this.answers['m06'] || 0)*1))) ?
-                           {'highlight': true, 'msg':'Too many big waters in use.'} : // validation failed
-                           {'highlight': false, 'msg':''};]]>
-        </Validate>
-    </Element>
-
-    <Element> 
-        <Heading>M17 Slingshot</Heading>
-	<Question>Slingshot is completely in the Slingshot target</Question>
-        <Tag>m17a</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m17a'] || 0)*20;]]></Score>
-    </Element>
-
-    <Element>
-        <Heading>M17 Slingshot</Heading>
-	<Question>Rain AND Dirty Water completely in the Slingshot target</Question>
-        <Tag>m17b</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m17a'] || 0)*1 && (this.answers['m17b'] || 0)*1 ? 15 : 0;]]></Score>
-    </Element>
-
-    <Element>
-        <Heading>M18 Faucet</Heading>
-	<Question>Water level is more blue than white</Question>
-        <Tag>m18</Tag>
-        <Option><Label>Yes</Label><Value>1</Value><Default/></Option>
-        <Option><Label>No</Label><Value>0</Value></Option>
-        <Score><![CDATA[score += (this.answers['m18'] || 0)*25;]]></Score>
-    </Element>
-
-    <Element>
-	<Heading>Penalties</Heading>
-	<Question>Penalty discs in the white triangle area</Question>
-        <Tag>m19</Tag>
-        <Option><Label>0</Label><Value>0</Value><Default/></Option>
-        <Option><Label>1</Label><Value>1</Value></Option>
-        <Option><Label>2</Label><Value>2</Value></Option>
-        <Option><Label>3</Label><Value>3</Value></Option>
-        <Option><Label>4</Label><Value>4</Value></Option>
-        <Option><Label>5</Label><Value>5</Value></Option>
-        <Score><![CDATA[score -= (this.answers['m19'] || 0)*5;]]></Score>
-    </Element>
 </Scoring_Elements>


### PR DESCRIPTION
I'm not sure about the status of this project and repository, but in Estonia we have [our own FLL systems](https://github.com/sim642/FLL-scorer), yet the robot game scoring was implemented based off the data files from this tournament system. I've been using the scoring data XML files from this repository in our own system for years now to ease the process.

I've noticed that there hasn't been an update for Into Orbit yet and wasn't sure if that is ever going to happen, so I decided to craft the scoring data XML from scratch myself for this season. Therefore I'm now just giving it back to you too if there's interest.

I haven't tested this XML with this actual tournament system so it might not even properly work for some odd reason, but it should be in the same format and could be useful nevertheless.